### PR TITLE
Disable pidfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN /appenv/bin/pip install --no-cache-dir /application
 
 EXPOSE 80
 WORKDIR "/db"
-CMD ["/appenv/bin/twistd", "--nodaemon", "fusion-index", "--db", "/db/fusion-index.axiom"]
+CMD ["/appenv/bin/twistd", "--nodaemon", "--pidfile", "", "fusion-index", "--db", "/db/fusion-index.axiom"]


### PR DESCRIPTION
The pidfile is unnecessary, and can prevent the service from being started after an unclean exit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fusionapp/fusion-index/159)
<!-- Reviewable:end -->
