### PR TITLE
Return the search type with search results.

### DIFF
--- a/src/fusion_index/search.py
+++ b/src/fusion_index/search.py
@@ -123,8 +123,9 @@ class SearchEntry(Item):
                 ])
             if searchType is not None:
                 criteria.append(SearchEntry.searchType == searchType)
-            return store.query(
-                SearchEntry, AND(*criteria), limit=limit).getColumn('result')
+            query = store.query(SearchEntry, AND(*criteria), limit=limit)
+            return [{u'result': item.result,
+                     u'type': item.searchType} for item in query]
 
 
     @classmethod

--- a/src/fusion_index/test/test_resource.py
+++ b/src/fusion_index/test/test_resource.py
@@ -242,7 +242,11 @@ class SearchAPITests(SynchronousTestCase):
              'indexType': u'someindex',
              'searchValue': u'somevalue',
              'searchType': None})
-        assertContainsFields(self, get1.end_message, {'results': [u'result']})
+        assertContainsFields(
+            self,
+            get1.end_message,
+            {'results': [{u'result': u'result',
+                          u'type': u'type'}]})
         self.assertTrue(get1.succeeded)
         assertContainsFields(
             self, get2.start_message,
@@ -278,7 +282,8 @@ class SearchAPITests(SynchronousTestCase):
             ['application/json'])
         self.assertEqual(
             json.loads(data(self, response)),
-            [u'result'])
+            [{u'result': u'result',
+              u'type': u'type'}])
 
         response = DELETE(
             self,
@@ -331,7 +336,7 @@ class SearchAPITests(SynchronousTestCase):
             response.headers.getRawHeaders('Content-Type'),
             ['application/json'])
         self.assertEqual(
-            set(json.loads(data(self, response))),
+            {r[u'result'] for r in json.loads(data(self, response))},
             {'result1', 'result2'})
 
         response = GET(
@@ -342,7 +347,8 @@ class SearchAPITests(SynchronousTestCase):
             ['application/json'])
         self.assertEqual(
             json.loads(data(self, response)),
-            ['result2'])
+            [{u'result': 'result2',
+              u'type': u'type2'}])
 
 
     def test_insertTwice(self):
@@ -364,7 +370,7 @@ class SearchAPITests(SynchronousTestCase):
             response.headers.getRawHeaders('Content-Type'),
             ['application/json'])
         self.assertEqual(
-            set(json.loads(data(self, response))),
+            {r[u'result'] for r in json.loads(data(self, response))},
             {'result'})
 
 
@@ -404,7 +410,11 @@ class SearchAPITests(SynchronousTestCase):
              'indexType': u'i',
              'searchValue': u'value',
              'searchType': None})
-        assertContainsFields(self, get1.end_message, {'results': [u'result1']})
+        assertContainsFields(
+            self,
+            get1.end_message,
+            {'results': [{u'result': u'result1',
+                          u'type': u'type1'}]})
         self.assertTrue(get1.succeeded)
         assertContainsFields(
             self, get2.start_message,
@@ -413,7 +423,11 @@ class SearchAPITests(SynchronousTestCase):
              'indexType': u'i',
              'searchValue': u'va',
              'searchType': None})
-        assertContainsFields(self, get2.end_message, {'results': [u'result2']})
+        assertContainsFields(
+            self,
+            get2.end_message,
+            {'results': [{u'result': u'result2',
+                          u'type': u'type2'}]})
         self.assertTrue(get2.succeeded)
 
 
@@ -439,7 +453,8 @@ class SearchAPITests(SynchronousTestCase):
             ['application/json'])
         self.assertEqual(
             json.loads(data(self, response)),
-            ['result1'])
+            [{u'result': 'result1',
+              u'type': u'type1'}])
 
         response = GET(
             self, agent, b'/search/prefix/e/i/results/va')
@@ -449,7 +464,8 @@ class SearchAPITests(SynchronousTestCase):
             ['application/json'])
         self.assertEqual(
             json.loads(data(self, response)),
-            ['result2'])
+            [{u'result': 'result2',
+              u'type': u'type2'}])
 
 
     def test_invalidSearchClass(self):

--- a/src/fusion_index/test/test_search.py
+++ b/src/fusion_index/test/test_search.py
@@ -37,12 +37,14 @@ class SearchTests(TestCase):
                 list(SearchEntry.search(
                     s, SearchClasses.EXACT, environment, indexType,
                     searchValue)),
-                Equals([result]))
+                Equals([{u'result': result,
+                         u'type': searchType}]))
             self.assertThat(
                 list(SearchEntry.search(
                     s, SearchClasses.EXACT, environment, indexType,
                     searchValue, searchType)),
-                Equals([result]))
+                Equals([{u'result': result,
+                         u'type': searchType}]))
 
             SearchEntry.remove(
                 s, SearchClasses.EXACT, environment, indexType, result,
@@ -79,7 +81,8 @@ class SearchTests(TestCase):
                 list(SearchEntry.search(
                     s, SearchClasses.PREFIX, environment, indexType,
                     searchValue[:3])),
-                Equals([result]))
+                Equals([{u'result': result,
+                         u'type': searchType}]))
             self.assertThat(
                 list(SearchEntry.search(
                     s, SearchClasses.PREFIX, environment, indexType,
@@ -89,12 +92,14 @@ class SearchTests(TestCase):
                 list(SearchEntry.search(
                     s, SearchClasses.PREFIX, environment, indexType,
                     searchValue)),
-                Equals([result]))
+                Equals([{u'result': result,
+                         u'type': searchType}]))
             self.assertThat(
                 list(SearchEntry.search(
                     s, SearchClasses.PREFIX, environment, indexType,
                     searchValue, searchType)),
-                Equals([result]))
+                Equals([{u'result': result,
+                         u'type': searchType}]))
 
             SearchEntry.remove(
                 s, SearchClasses.PREFIX, environment, indexType, result,
@@ -142,7 +147,8 @@ class SearchTests(TestCase):
                     Annotate(
                         'Not found for {!r}({!r}) == {!r}'.format(
                             mutation, value, mutation(value)),
-                        Equals([u'RESULT'])))
+                        Equals([{u'result': u'RESULT',
+                                 u'type': u'type'}])))
         s.transact(_tx)
 
 


### PR DESCRIPTION
This involves a backwards-incompatible change to the return structure of search results: From a list of results to a list of dicts of result information.

Fixes #212.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fusionapp/fusion-index/213)
<!-- Reviewable:end -->
